### PR TITLE
chore: commitlint 設定を TypeScript 化

### DIFF
--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,4 +1,6 @@
-export default {
+import type { UserConfig } from '@commitlint/types'
+
+const config: UserConfig = {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [
@@ -15,11 +17,13 @@ export default {
         'build',
         'ci',
         'chore',
-        'revert'
-      ]
+        'revert',
+      ],
     ],
     'subject-case': [0],
     'subject-full-stop': [2, 'never', '.'],
-    'header-max-length': [2, 'always', 72]
-  }
+    'header-max-length': [2, 'always', 72],
+  },
 }
+
+export default config

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
+    "@commitlint/types": "19.8.1",
     "@eslint/js": "9.28.0",
     "@stylistic/eslint-plugin": "4.4.1",
     "@types/node": "22.15.30",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: 19.8.1
         version: 19.8.1
+      '@commitlint/types':
+        specifier: 19.8.1
+        version: 19.8.1
       '@eslint/js':
         specifier: 9.28.0
         version: 9.28.0


### PR DESCRIPTION
## 概要
commitlint の設定ファイルを JavaScript から TypeScript に移行しました。

## 変更内容
- `commitlint.config.js` を `commitlint.config.ts` に変換
- 型安全性向上のため `@commitlint/types` を devDependencies に追加
- 設定内容自体は変更なし

## テスト方法
- [ ] `pnpm run lint` が正常に動作すること
- [ ] コミット時の pre-commit hook が正常に動作すること
- [ ] 不正なコミットメッセージが正しく拒否されること

## チェックリスト
- [x] 既存のテストがすべてパスすること
- [x] TypeScript の型チェックが通ること
- [x] ESLint のチェックが通ること