### PR TITLE
chore: ESLint 設定ファイルを TypeScript 化

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,8 +1,9 @@
 import js from '@eslint/js'
 import stylistic from '@stylistic/eslint-plugin'
 import tseslint from 'typescript-eslint'
+import type { ConfigArray } from 'typescript-eslint'
 
-export default tseslint.config(
+const config: ConfigArray = tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
@@ -14,7 +15,7 @@ export default tseslint.config(
       '@typescript-eslint/no-unused-vars': 'error',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/explicit-module-boundary-types': 'warn',
-      
+
       // スタイル関連（@stylistic/eslint-plugin）
       '@stylistic/indent': ['error', 2],
       '@stylistic/quotes': ['error', 'single'],
@@ -32,7 +33,7 @@ export default tseslint.config(
         named: 'never',
         asyncArrow: 'always'
       }],
-      
+
       // 一般的なルール
       'no-console': 'warn',
       'no-debugger': 'error',
@@ -40,7 +41,7 @@ export default tseslint.config(
       'no-var': 'error',
       'object-shorthand': 'error',
       'prefer-template': 'error',
-      
+
       // バレルファイル（index ファイル）からの import を禁止
       'no-restricted-imports': ['error', {
         patterns: [
@@ -82,6 +83,8 @@ export default tseslint.config(
     }
   },
   {
-    ignores: ['dist/**', 'node_modules/**', 'coverage/**', '*.config.js']
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**', '*.config.js', '*.config.ts', '*.config.mts', '*.config.cts']
   }
 )
+
+export default config

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/node": "22.15.30",
     "@vitest/coverage-v8": "3.2.3",
     "eslint": "9.28.0",
+    "jiti": "2.4.2",
     "lefthook": "1.11.13",
     "sort-package-json": "3.2.1",
     "tsup": "8.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,13 @@ importers:
         version: 22.15.30
       '@vitest/coverage-v8':
         specifier: 3.2.3
-        version: 3.2.3(vitest@3.2.3(@types/node@22.15.30)(jiti@2.4.2))
+        version: 3.2.3(vitest@3.2.3(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3))
       eslint:
         specifier: 9.28.0
         version: 9.28.0(jiti@2.4.2)
+      jiti:
+        specifier: 2.4.2
+        version: 2.4.2
       lefthook:
         specifier: 1.11.13
         version: 1.11.13
@@ -40,7 +43,7 @@ importers:
         version: 3.2.1
       tsup:
         specifier: 8.5.0
-        version: 8.5.0(jiti@2.4.2)(postcss@8.5.4)(typescript@5.8.3)
+        version: 8.5.0(jiti@2.4.2)(postcss@8.5.4)(tsx@4.20.3)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -49,7 +52,7 @@ importers:
         version: 8.33.1(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       vitest:
         specifier: 3.2.3
-        version: 3.2.3(@types/node@22.15.30)(jiti@2.4.2)
+        version: 3.2.3(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3)
 
 packages:
 
@@ -965,6 +968,9 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   git-hooks-list@4.1.1:
     resolution: {integrity: sha512-cmP497iLq54AZnv4YRAEMnEyQ1eIn4tGKbmswqwmFV4GBnAqE8NLtWxxdXa++AalfgL5EBH4IxTPyquEuGY/jA==}
 
@@ -1414,6 +1420,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -1584,6 +1593,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2232,7 +2246,7 @@ snapshots:
       '@typescript-eslint/types': 8.33.1
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/coverage-v8@3.2.3(vitest@3.2.3(@types/node@22.15.30)(jiti@2.4.2))':
+  '@vitest/coverage-v8@3.2.3(vitest@3.2.3(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2247,7 +2261,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.3(@types/node@22.15.30)(jiti@2.4.2)
+      vitest: 3.2.3(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -2259,13 +2273,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2))':
+  '@vitest/mocker@3.2.3(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3))':
     dependencies:
       '@vitest/spy': 3.2.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.3.5(@types/node@22.15.30)(jiti@2.4.2)
+      vite: 6.3.5(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3)
 
   '@vitest/pretty-format@3.2.3':
     dependencies:
@@ -2654,6 +2668,11 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    optional: true
+
   git-hooks-list@4.1.1: {}
 
   git-raw-commits@4.0.0:
@@ -2992,12 +3011,13 @@ snapshots:
       mlly: 1.7.4
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.20.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.4.2
       postcss: 8.5.4
+      tsx: 4.20.3
 
   postcss@8.5.4:
     dependencies:
@@ -3020,6 +3040,9 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   reusify@1.1.0: {}
 
@@ -3180,7 +3203,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.0(jiti@2.4.2)(postcss@8.5.4)(typescript@5.8.3):
+  tsup@8.5.0(jiti@2.4.2)(postcss@8.5.4)(tsx@4.20.3)(typescript@5.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.5)
       cac: 6.7.14
@@ -3191,7 +3214,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.4)
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.20.3)
       resolve-from: 5.0.0
       rollup: 4.42.0
       source-map: 0.8.0-beta.0
@@ -3207,6 +3230,14 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.20.3:
+    dependencies:
+      esbuild: 0.25.5
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    optional: true
 
   type-check@0.4.0:
     dependencies:
@@ -3234,13 +3265,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.3(@types/node@22.15.30)(jiti@2.4.2):
+  vite-node@3.2.3(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.30)(jiti@2.4.2)
+      vite: 6.3.5(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3255,7 +3286,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2):
+  vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.4.5(picomatch@4.0.2)
@@ -3267,12 +3298,13 @@ snapshots:
       '@types/node': 22.15.30
       fsevents: 2.3.3
       jiti: 2.4.2
+      tsx: 4.20.3
 
-  vitest@3.2.3(@types/node@22.15.30)(jiti@2.4.2):
+  vitest@3.2.3(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.3
-      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2))
+      '@vitest/mocker': 3.2.3(vite@6.3.5(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3))
       '@vitest/pretty-format': 3.2.3
       '@vitest/runner': 3.2.3
       '@vitest/snapshot': 3.2.3
@@ -3290,8 +3322,8 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.0
       tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@22.15.30)(jiti@2.4.2)
-      vite-node: 3.2.3(@types/node@22.15.30)(jiti@2.4.2)
+      vite: 6.3.5(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3)
+      vite-node: 3.2.3(@types/node@22.15.30)(jiti@2.4.2)(tsx@4.20.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.30


### PR DESCRIPTION
## 概要

ESLint の設定ファイルを JavaScript から TypeScript に移行しました。

## 変更内容

- `jiti` パッケージを devDependencies に追加（TypeScript 設定ファイルサポート）
- `eslint.config.js` を `eslint.config.ts` にリネーム
- 型安全性向上のため `ConfigArray` 型を明示的に指定
- ignores パターンに TypeScript 設定ファイルのパターンを追加

## メリット

- 設定ファイルの型安全性が向上
- IDE での IntelliSense サポート
- より保守性の高いコード
- TypeScript プロジェクトとしての一貫性

## テスト

- `pnpm run lint` - ESLint 実行確認
- `pnpm run type-check` - TypeScript 型チェック確認
- pre-commit hooks の動作確認

## 関連

- ESLint 公式ドキュメント: https://eslint.org/docs/latest/use/configure/configuration-files#typescript-configuration-files